### PR TITLE
Visibility timeout and bug fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 .classpath
 .project
+.idea
+*.iml
 .settings
 bin/
 build/
 .gradle
 test-stream.properties
-

--- a/README.md
+++ b/README.md
@@ -25,18 +25,18 @@ Using the EventBus is very easy:
 EventBus bus = EventBus.create(Environment.initializeIfEmpty(), Environment.THREAD_POOL);
 ```
 
-To subscribe to all events publsihed on the bus:
+To subscribe to all events published on the bus:
 
 ```java
-bus.on(Selectors.matchAll(),e-> {
-  System.out.println("Hello, "+e.getData());
+bus.on(Selectors.matchAll(),e -> {
+  System.out.println("Hello, " + e.getData());
 });
 ````
 
 To publish an event:
 
 ```java
-bus.notify("greeting",Event.wrap("World!"));
+bus.notify("greeting", Event.wrap("World!"));
 ```
 
 Will yield the following output:
@@ -84,7 +84,7 @@ This will cause SNS messages to be parsed and re-emitted as ```Event<SNSMessage>
 
 # Kinesis
 
-The following code will start a Kinesis Consumer Libarary (KCL) worker instance that will read 
+The following code will start a Kinesis Consumer Library (KCL) worker instance that will read 
 from the stream named ```mystream``` located in the ```us-west-1``` region.  It will publish events
 onto the specified EventBus.
 
@@ -100,14 +100,14 @@ new KinesisReactorBridge.Builder()
 This can subscribed to similarly:
 
 ```java
-bus.on(Selectors.type(KinesisRecord.cass), it -> {
+bus.on(Selectors.type(KinesisRecord.class), it -> {
     System.out.println(it);
 });
 ```
 
 # Selectors and Predicates
 
-When Message objects are publshed onto the event bus, they are wrapped in an SQSMessage object.  This SQSMessage object is used as the key for the
+When Message objects are published onto the event bus, they are wrapped in an SQSMessage object.  This SQSMessage object is used as the key for the
 publish operation.
 
 This makes it possible to filter messages for subscription.  This is an example of a Lambda Predicate that matches any SQSMessage that comes from the ```test``` stream:
@@ -153,7 +153,7 @@ And there are several Selectors that apply only to SQS:
 | SQSMessageSelectors.queueName(String name) | Matches the queue name via URL |
 
 
-And a number that are speicific to Kinesis:
+And a number that are specific to Kinesis:
 
 | Selector | Description |
 |----------| ----------- |

--- a/src/main/java/io/macgyver/reactor/aws/kinesis/CheckpointStrategy.java
+++ b/src/main/java/io/macgyver/reactor/aws/kinesis/CheckpointStrategy.java
@@ -18,6 +18,5 @@ import com.amazonaws.services.kinesis.model.Record;
 import rx.functions.Func1;
 
 public interface CheckpointStrategy extends Func1<Record, Boolean> {
-
-	public Boolean call(Record record);
+	Boolean call(Record record);
 }

--- a/src/main/java/io/macgyver/reactor/aws/kinesis/JsonParsingConsumer.java
+++ b/src/main/java/io/macgyver/reactor/aws/kinesis/JsonParsingConsumer.java
@@ -29,22 +29,18 @@ import reactor.fn.Consumer;
 
 public class JsonParsingConsumer implements Consumer<Event<KinesisReactorBridge.KinesisRecord>> {
 
-	Logger logger = LoggerFactory.getLogger(JsonParsingConsumer.class);
-
-	ObjectMapper mapper = new ObjectMapper();
+	private static final Logger logger = LoggerFactory.getLogger(JsonParsingConsumer.class);
+	private ObjectMapper mapper = new ObjectMapper();
 
 	@Override
 	public void accept(Event<KinesisReactorBridge.KinesisRecord> t) {
 
 		try {
-			KinesisRecord record = (KinesisRecord) t.getData();
-
+			KinesisRecord record = t.getData();
 			JsonNode n = mapper.readTree(new ByteBufferBackedInputStream(record.getRecord().getData()));
-
 			Event<JsonNode> event = Event.wrap(n);
 			EventUtil.copyEventHeaders(t, event);
 			record.getBridge().getEventBus().notify(n, event);
-
 		} catch (IOException | RuntimeException e) {
 			if (logger.isDebugEnabled()) {
 				logger.debug("could not parse json", e);

--- a/src/main/java/io/macgyver/reactor/aws/kinesis/KinesisReactorBridge.java
+++ b/src/main/java/io/macgyver/reactor/aws/kinesis/KinesisReactorBridge.java
@@ -2,9 +2,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/io/macgyver/reactor/aws/kinesis/KinesisReactorBridge.java
+++ b/src/main/java/io/macgyver/reactor/aws/kinesis/KinesisReactorBridge.java
@@ -2,9 +2,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,18 +12,6 @@
  * limitations under the License.
  */
 package io.macgyver.reactor.aws.kinesis;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-import java.nio.ByteBuffer;
-import java.util.UUID;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Consumer;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
@@ -49,346 +37,339 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
-
 import io.macgyver.reactor.aws.AbstractReactorBridge;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import reactor.bus.Event;
 import reactor.bus.EventBus;
 import reactor.bus.selector.Selector;
 import reactor.bus.selector.Selectors;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.nio.ByteBuffer;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
 public class KinesisReactorBridge extends AbstractReactorBridge {
 
-	static Logger logger = LoggerFactory.getLogger(KinesisReactorBridge.class);
-	KinesisClientLibConfiguration kinesisConfig;
-
-	Worker worker;
+    private static final Logger logger = LoggerFactory.getLogger(KinesisReactorBridge.class);
+    private KinesisClientLibConfiguration kinesisConfig;
 
-	AmazonKinesisAsyncClient asyncKinesisClient;
+    private Worker worker;
 
-	AtomicInteger bridgeThreadNum = new AtomicInteger(0);
+    private AmazonKinesisAsyncClient asyncKinesisClient;
 
-	boolean parseJson = false;
+    private final AtomicInteger bridgeThreadNum = new AtomicInteger(0);
 
-	CheckpointStrategy checkpointStrategy = new TimeIntervalCheckpointStrategy();
+    private boolean parseJson = false;
 
-	Supplier<String> streamArnSupplier = Suppliers.memoize(new StreamArnSupplier());
-	
-	ObjectMapper mapper = new ObjectMapper();
-	
-	public class StreamArnSupplier implements Supplier<String> {
+    private CheckpointStrategy checkpointStrategy = new TimeIntervalCheckpointStrategy();
 
-		@Override
-		public String get() {
-			return getKinesisClient().describeStream(getStreamName()).getStreamDescription().getStreamARN();
-		}
+    private Supplier<String> streamArnSupplier = Suppliers.memoize(new StreamArnSupplier());
+
+    private ObjectMapper mapper = new ObjectMapper();
+
+    public class StreamArnSupplier implements Supplier<String> {
+
+        @Override
+        public String get() {
+            return getKinesisClient().describeStream(getStreamName()).getStreamDescription().getStreamARN();
+        }
+
+    }
+
+    public class KinesisRecord {
 
-	}
+        private Record record;
 
-	public class KinesisRecord {
+        private JsonNode jsonBody = null;
 
-		
-		
-		Record record;
-
-		JsonNode jsonBody = null;
-		
-		public Record getRecord() {
-			return record;
-		}
-
-		public String getStreamName() {
-			return kinesisConfig.getStreamName();
-		}
-
-		public String getStreamArn() {
-			return KinesisReactorBridge.this.getStreamArn();
-		}
-
-		public KinesisReactorBridge getBridge() {
-			return KinesisReactorBridge.this;
-		}
-
-		public String getSequenceNumber() {
-			return getRecord().getSequenceNumber();
-		}
-
-		public InputStream getBodyAsInputStream() {
-			return new ByteBufferBackedInputStream(getRecord().getData().duplicate());
-		}
-
-		public byte[] getBodyAsByteArray() {
-			return toByteArray(getRecord().getData().duplicate());
-		}
-
-		public String getBodyAsString() {
-			return new String(getBodyAsByteArray());
-		}
-		public synchronized JsonNode getBodyAsJson() {
-			if (jsonBody==null) {
-				try {
-				jsonBody = mapper.readTree(getBodyAsByteArray());
-				}
-				catch (IOException e) {
-					jsonBody = MissingNode.getInstance();
-					logger.warn("could not parse json body: "+e.toString());
-				}
-			}
-			
-			return jsonBody;
-		}
-	}
-
-	private static byte[] toByteArray(ByteBuffer bb) {
-
-		if (bb.hasArray()) {
-			return bb.array();
-		} else {
-			byte[] bytes = new byte[bb.remaining()];
-			bb.get(bytes);
-			return bytes;
-		}
-	}
-
-	class BridgeRecordProcessor implements IRecordProcessor {
-
-		@Override
-		public void initialize(InitializationInput initializationInput) {
-
-			logger.info("initializing {} with {}", this, initializationInput);
-
-		}
-
-		@Override
-		public void processRecords(ProcessRecordsInput processRecordsInput) {
-
-			logger.info("processRecords");
-			processRecordsInput.getRecords().forEach(record -> {
-
-				KinesisRecord kr = new KinesisRecord();
-				kr.record = record;
-				Event<KinesisRecord> event = Event.wrap(kr);
-
-				getEventBus().notify(kr, event);
-
-				boolean cp = checkpointStrategy.call(record);
-
-				if (cp) {
-					try {
-
-						if (logger.isDebugEnabled()) {
-							logger.debug("checkpointing app {} for stream {} at {}", kinesisConfig.getApplicationName(),
-									kinesisConfig.getStreamName(), record.getSequenceNumber());
-						}
-						processRecordsInput.getCheckpointer().checkpoint(record);
-
-					} catch (RuntimeException | InvalidStateException | ShutdownException e) {
-						logger.error("problem with checkpoint", e);
-					}
-				}
-
-			});
-
-		}
-
-		@Override
-		public void shutdown(ShutdownInput shutdownInput) {
-			logger.info("shutdown {}", shutdownInput);
-
-		}
-
-	}
-
-	public static class Builder {
-
-		KinesisClientLibConfiguration kinesisConfig = null;
-		EventBus eventBus;
-		String arn;
-		boolean parseJson = false;
-		String appName;
-		String streamName;
-		String regionName;
-		AWSCredentialsProvider credentialsProvider;
-		Consumer<KinesisClientLibConfiguration> extraConfig;
-		String workerId;
-
-		CheckpointStrategy checkpointStrategy;
-
-		public Builder withStreamName(String streamName) {
-			this.streamName = streamName;
-			return this;
-		}
-
-		public Builder withRegion(Regions region) {
-			return withRegion(Region.getRegion(region));
-		}
-
-		public Builder withRegion(Region region) {
-			return withRegion(region.getName());
-		}
-
-		public Builder withRegion(String region) {
-			this.regionName = region;
-			return this;
-		}
-
-		public Builder withAppName(String appName) {
-			this.appName = appName;
-			return this;
-		}
-
-		public Builder withEventBus(EventBus bus) {
-			this.eventBus = bus;
-			return this;
-		}
-
-		public Builder withJsonParsing(boolean b) {
-			parseJson = b;
-			return this;
-		}
-
-		public Builder withKinesisConfig(KinesisClientLibConfiguration cfg) {
-			this.kinesisConfig = cfg;
-			return this;
-		}
-
-		public Builder withCheckpointStrategy(CheckpointStrategy strategy) {
-			this.checkpointStrategy = strategy;
-			return this;
-		}
-
-		public Builder withAdditionalConfig(Consumer<KinesisClientLibConfiguration> cfg) {
-
-			extraConfig = cfg;
-			return this;
-		}
-
-		public KinesisReactorBridge build() {
-
-			Preconditions.checkArgument(eventBus != null, "EventBus cannot be null");
-			KinesisReactorBridge bridge = new KinesisReactorBridge();
-
-			if (kinesisConfig == null) {
-				Preconditions.checkArgument(!Strings.isNullOrEmpty(streamName), "streamName must be set");
-				if (credentialsProvider == null) {
-					credentialsProvider = new DefaultAWSCredentialsProviderChain();
-				}
-				if (workerId == null) {
-					try {
-						workerId = InetAddress.getLocalHost().getCanonicalHostName() + ":" + UUID.randomUUID();
-					} catch (UnknownHostException e) {
-						workerId = "127.0.0.1:" + bridge.getId();
-					}
-				}
-				Preconditions.checkArgument(appName != null, "appName must be set");
-				kinesisConfig = new KinesisClientLibConfiguration(appName, streamName, credentialsProvider,
-						workerId);
-				if (regionName != null) {
-					kinesisConfig.withRegionName(regionName);
-				}
-			}
-
-			bridge.kinesisConfig = kinesisConfig;
-
-			if (checkpointStrategy != null) {
-				bridge.checkpointStrategy = checkpointStrategy;
-			}
-
-			if (extraConfig != null) {
-				extraConfig.accept(bridge.kinesisConfig);
-			}
-			bridge.eventBus = eventBus;
-
-			AmazonKinesisAsyncClient asyncClient = new AmazonKinesisAsyncClient(
-					kinesisConfig.getKinesisCredentialsProvider());
-
-			if (kinesisConfig.getRegionName() != null) {
-				asyncClient.setRegion(Region.getRegion(Regions.fromName(kinesisConfig.getRegionName())));
-			}
-			bridge.asyncKinesisClient = asyncClient;
-			if (bridge.parseJson) {
-				JsonParsingConsumer.apply(bridge);
-			}
-
-			logger.info("bridgeId  : {}", bridge.getId());
-			logger.info("appName   : {}", kinesisConfig.getApplicationName());
-			logger.info("streamName: {}", kinesisConfig.getStreamName());
-			logger.info("regionName: {}", kinesisConfig.getRegionName());
-			logger.info("workerId  : {}", kinesisConfig.getWorkerIdentifier());
-			logger.info("streamArn : {}", bridge.getStreamArn());
-
-			logger.info("created {} ... don't forget to call start()", bridge);
-			return bridge;
-		}
-	}
-
-	public KinesisReactorBridge start() {
-		logger.info("starting {}...", this);
-		IRecordProcessorFactory factory = new IRecordProcessorFactory() {
-
-			@Override
-			public IRecordProcessor createProcessor() {
-				BridgeRecordProcessor p = new BridgeRecordProcessor();
-				logger.info("creating {}", p);
-				return p;
-			}
-		};
-
-		Preconditions.checkNotNull(kinesisConfig);
-		worker = new Worker.Builder()
-				.recordProcessorFactory(factory)
-				.config(kinesisConfig)
-				.build();
-
-		Thread t = new Thread(worker);
-		t.setDaemon(true);
-		t.setName("kinesis-bridge-" + bridgeThreadNum.getAndIncrement());
-		t.start();
-
-		return this;
-	}
-
-	protected KinesisReactorBridge() {
-
-	}
-
-	public String getArn() {
-		return getStreamArn();
-	}
-
-	public String getStreamName() {
-		if (kinesisConfig == null) {
-			return null;
-		}
-		return kinesisConfig.getStreamName();
-	}
-
-	public KinesisClientLibConfiguration getKinesisClientLibConfiguration() {
-		return kinesisConfig;
-	}
-
-	public String getStreamArn() {
-		return streamArnSupplier.get();
-
-	}
-
-	public Selector eventsFromBridgeSelector() {
-		return Selectors.predicate(p -> {
-			if (p instanceof KinesisRecord) {
-				return ((KinesisRecord) p).getBridge() == this;
-			}
-			return false;
-		});
-	}
-
-	public AmazonKinesisAsyncClient getKinesisClient() {
-		return asyncKinesisClient;
-	}
-
-	public void stop() {
-		worker.shutdown();
-	}
-
-	public String toString() {
-		return MoreObjects.toStringHelper(this).add("streamName", getStreamName()).toString();
-	}
+        public Record getRecord() {
+            return record;
+        }
+
+        public String getStreamName() {
+            return kinesisConfig.getStreamName();
+        }
+
+        public String getStreamArn() {
+            return KinesisReactorBridge.this.getStreamArn();
+        }
+
+        public KinesisReactorBridge getBridge() {
+            return KinesisReactorBridge.this;
+        }
+
+        public String getSequenceNumber() {
+            return getRecord().getSequenceNumber();
+        }
+
+        public InputStream getBodyAsInputStream() {
+            return new ByteBufferBackedInputStream(getRecord().getData().duplicate());
+        }
+
+        public byte[] getBodyAsByteArray() {
+            return toByteArray(getRecord().getData().duplicate());
+        }
+
+        public String getBodyAsString() {
+            return new String(getBodyAsByteArray());
+        }
+
+        public synchronized JsonNode getBodyAsJson() {
+            if (jsonBody == null) {
+                try {
+                    jsonBody = mapper.readTree(getBodyAsByteArray());
+                } catch (IOException e) {
+                    jsonBody = MissingNode.getInstance();
+                    logger.warn("could not parse json body: " + e.toString());
+                }
+            }
+
+            return jsonBody;
+        }
+    }
+
+    private static byte[] toByteArray(ByteBuffer bb) {
+
+        if (bb.hasArray()) {
+            return bb.array();
+        } else {
+            byte[] bytes = new byte[bb.remaining()];
+            bb.get(bytes);
+            return bytes;
+        }
+    }
+
+    class BridgeRecordProcessor implements IRecordProcessor {
+
+        @Override
+        public void initialize(InitializationInput initializationInput) {
+            logger.info("initializing {} with {}", this, initializationInput);
+        }
+
+        @Override
+        public void processRecords(ProcessRecordsInput processRecordsInput) {
+            logger.info("processRecords");
+            processRecordsInput.getRecords().forEach(record -> {
+                KinesisRecord kr = new KinesisRecord();
+                kr.record = record;
+                Event<KinesisRecord> event = Event.wrap(kr);
+                getEventBus().notify(kr, event);
+                boolean cp = checkpointStrategy.call(record);
+                if (cp) {
+                    try {
+                        if (logger.isDebugEnabled()) {
+                            logger.debug("checkpointing app {} for stream {} at {}", kinesisConfig.getApplicationName(),
+                                    kinesisConfig.getStreamName(), record.getSequenceNumber());
+                        }
+                        processRecordsInput.getCheckpointer().checkpoint(record);
+                    } catch (RuntimeException | InvalidStateException | ShutdownException e) {
+                        logger.error("problem with checkpoint", e);
+                    }
+                }
+            });
+        }
+
+        @Override
+        public void shutdown(ShutdownInput shutdownInput) {
+            logger.info("shutdown {}", shutdownInput);
+
+        }
+
+    }
+
+    public static class Builder {
+
+        private KinesisClientLibConfiguration kinesisConfig = null;
+        private EventBus eventBus;
+        private String arn;
+        private boolean parseJson = false;
+        private String appName;
+        private String streamName;
+        private String regionName;
+        private AWSCredentialsProvider credentialsProvider;
+        private Consumer<KinesisClientLibConfiguration> extraConfig;
+        private String workerId;
+
+        CheckpointStrategy checkpointStrategy;
+
+        public Builder withStreamName(String streamName) {
+            this.streamName = streamName;
+            return this;
+        }
+
+        public Builder withRegion(Regions region) {
+            return withRegion(Region.getRegion(region));
+        }
+
+        public Builder withRegion(Region region) {
+            return withRegion(region.getName());
+        }
+
+        public Builder withRegion(String region) {
+            this.regionName = region;
+            return this;
+        }
+
+        public Builder withAppName(String appName) {
+            this.appName = appName;
+            return this;
+        }
+
+        public Builder withEventBus(EventBus bus) {
+            this.eventBus = bus;
+            return this;
+        }
+
+        public Builder withJsonParsing(boolean b) {
+            parseJson = b;
+            return this;
+        }
+
+        public Builder withKinesisConfig(KinesisClientLibConfiguration cfg) {
+            this.kinesisConfig = cfg;
+            return this;
+        }
+
+        public Builder withCheckpointStrategy(CheckpointStrategy strategy) {
+            this.checkpointStrategy = strategy;
+            return this;
+        }
+
+        public Builder withAdditionalConfig(Consumer<KinesisClientLibConfiguration> cfg) {
+
+            extraConfig = cfg;
+            return this;
+        }
+
+        public KinesisReactorBridge build() {
+
+            Preconditions.checkArgument(eventBus != null, "EventBus cannot be null");
+            KinesisReactorBridge bridge = new KinesisReactorBridge();
+
+            if (kinesisConfig == null) {
+                Preconditions.checkArgument(!Strings.isNullOrEmpty(streamName), "streamName must be set");
+                if (credentialsProvider == null) {
+                    credentialsProvider = new DefaultAWSCredentialsProviderChain();
+                }
+                if (workerId == null) {
+                    try {
+                        workerId = InetAddress.getLocalHost().getCanonicalHostName() + ":" + UUID.randomUUID();
+                    } catch (UnknownHostException e) {
+                        workerId = "127.0.0.1:" + bridge.getId();
+                    }
+                }
+                Preconditions.checkArgument(appName != null, "appName must be set");
+                kinesisConfig = new KinesisClientLibConfiguration(appName, streamName, credentialsProvider,
+                        workerId);
+                if (regionName != null) {
+                    kinesisConfig.withRegionName(regionName);
+                }
+            }
+
+            bridge.kinesisConfig = kinesisConfig;
+
+            if (checkpointStrategy != null) {
+                bridge.checkpointStrategy = checkpointStrategy;
+            }
+
+            if (extraConfig != null) {
+                extraConfig.accept(bridge.kinesisConfig);
+            }
+            bridge.eventBus = eventBus;
+
+            AmazonKinesisAsyncClient asyncClient = new AmazonKinesisAsyncClient(
+                    kinesisConfig.getKinesisCredentialsProvider());
+
+            if (kinesisConfig.getRegionName() != null) {
+                asyncClient.setRegion(Region.getRegion(Regions.fromName(kinesisConfig.getRegionName())));
+            }
+            bridge.asyncKinesisClient = asyncClient;
+            if (bridge.parseJson) {
+                JsonParsingConsumer.apply(bridge);
+            }
+
+            logger.info("bridgeId  : {}", bridge.getId());
+            logger.info("appName   : {}", kinesisConfig.getApplicationName());
+            logger.info("streamName: {}", kinesisConfig.getStreamName());
+            logger.info("regionName: {}", kinesisConfig.getRegionName());
+            logger.info("workerId  : {}", kinesisConfig.getWorkerIdentifier());
+            logger.info("streamArn : {}", bridge.getStreamArn());
+
+            logger.info("created {} ... don't forget to call start()", bridge);
+            return bridge;
+        }
+    }
+
+    public KinesisReactorBridge start() {
+        logger.info("starting {}...", this);
+        IRecordProcessorFactory factory = () -> {
+            BridgeRecordProcessor p = new BridgeRecordProcessor();
+            logger.info("creating {}", p);
+            return p;
+        };
+
+        Preconditions.checkNotNull(kinesisConfig);
+        worker = new Worker.Builder()
+                .recordProcessorFactory(factory)
+                .config(kinesisConfig)
+                .build();
+
+        Thread t = new Thread(worker);
+        t.setDaemon(true);
+        t.setName("kinesis-bridge-" + bridgeThreadNum.getAndIncrement());
+        t.start();
+
+        return this;
+    }
+
+    protected KinesisReactorBridge() {
+
+    }
+
+    public String getArn() {
+        return getStreamArn();
+    }
+
+    public String getStreamName() {
+        if (kinesisConfig == null) {
+            return null;
+        }
+        return kinesisConfig.getStreamName();
+    }
+
+    public KinesisClientLibConfiguration getKinesisClientLibConfiguration() {
+        return kinesisConfig;
+    }
+
+    public String getStreamArn() {
+        return streamArnSupplier.get();
+
+    }
+
+    public Selector eventsFromBridgeSelector() {
+        return Selectors.predicate(p -> {
+            if (p instanceof KinesisRecord) {
+                return ((KinesisRecord) p).getBridge() == this;
+            }
+            return false;
+        });
+    }
+
+    public AmazonKinesisAsyncClient getKinesisClient() {
+        return asyncKinesisClient;
+    }
+
+    public void stop() {
+        worker.shutdown();
+    }
+
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("streamName", getStreamName()).toString();
+    }
 }

--- a/src/main/java/io/macgyver/reactor/aws/kinesis/KinesisReactorBridge.java
+++ b/src/main/java/io/macgyver/reactor/aws/kinesis/KinesisReactorBridge.java
@@ -195,8 +195,7 @@ public class KinesisReactorBridge extends AbstractReactorBridge {
         private AWSCredentialsProvider credentialsProvider;
         private Consumer<KinesisClientLibConfiguration> extraConfig;
         private String workerId;
-
-        CheckpointStrategy checkpointStrategy;
+        private CheckpointStrategy checkpointStrategy;
 
         public Builder withStreamName(String streamName) {
             this.streamName = streamName;
@@ -290,7 +289,7 @@ public class KinesisReactorBridge extends AbstractReactorBridge {
                 asyncClient.setRegion(Region.getRegion(Regions.fromName(kinesisConfig.getRegionName())));
             }
             bridge.asyncKinesisClient = asyncClient;
-            if (bridge.parseJson) {
+            if (parseJson) {
                 JsonParsingConsumer.apply(bridge);
             }
 

--- a/src/main/java/io/macgyver/reactor/aws/kinesis/KinesisRecordSelectors.java
+++ b/src/main/java/io/macgyver/reactor/aws/kinesis/KinesisRecordSelectors.java
@@ -2,9 +2,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/io/macgyver/reactor/aws/kinesis/KinesisRecordSelectors.java
+++ b/src/main/java/io/macgyver/reactor/aws/kinesis/KinesisRecordSelectors.java
@@ -2,9 +2,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,46 +13,37 @@
  */
 package io.macgyver.reactor.aws.kinesis;
 
+import io.macgyver.reactor.aws.kinesis.KinesisReactorBridge.KinesisRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import io.macgyver.reactor.aws.kinesis.KinesisReactorBridge.KinesisRecord;
 import reactor.bus.selector.Selector;
 import reactor.bus.selector.Selectors;
 
 public class KinesisRecordSelectors {
 
-	static Logger logger = LoggerFactory.getLogger(KinesisRecordSelectors.class);
+    private static final Logger logger = LoggerFactory.getLogger(KinesisRecordSelectors.class);
 
-	public static Selector anyKinesisRecord() {
-		return Selectors.type(KinesisRecord.class);
-	}
+    public static Selector anyKinesisRecord() {
+        return Selectors.type(KinesisRecord.class);
+    }
 
-	public static Selector streamArn(String arn) {
-		return Selectors.predicate(it -> {
+    public static Selector streamArn(String arn) {
+        return Selectors.predicate(it -> {
+            if (it instanceof KinesisRecord) {
+                KinesisRecord kr = (KinesisRecord) it;
+                return arn.equals(kr.getStreamArn());
+            }
+            return false;
+        });
+    }
 
-			if (it instanceof KinesisRecord) {
-				KinesisRecord kr = (KinesisRecord) it;
-
-				return arn.equals(kr.getStreamArn());
-
-			}
-			return false;
-
-		});
-	}
-
-	public static Selector streamName(String name) {
-		return Selectors.predicate(it -> {
-
-			if (it instanceof KinesisRecord) {
-				KinesisRecord kr = (KinesisRecord) it;
-
-				return kr.getStreamName().equals(name);
-
-			}
-			return false;
-
-		});
-	}
+    public static Selector streamName(String name) {
+        return Selectors.predicate(it -> {
+            if (it instanceof KinesisRecord) {
+                KinesisRecord kr = (KinesisRecord) it;
+                return kr.getStreamName().equals(name);
+            }
+            return false;
+        });
+    }
 }

--- a/src/main/java/io/macgyver/reactor/aws/kinesis/TimeIntervalCheckpointStrategy.java
+++ b/src/main/java/io/macgyver/reactor/aws/kinesis/TimeIntervalCheckpointStrategy.java
@@ -23,10 +23,10 @@ import com.amazonaws.services.kinesis.model.Record;
 
 public class TimeIntervalCheckpointStrategy implements CheckpointStrategy {
 
+	private static final Logger logger = LoggerFactory.getLogger(TimeIntervalCheckpointStrategy.class);
 	public static final long DEFAULT_INTERVAL_MILLIS = TimeUnit.SECONDS.toMillis(30);
-	AtomicLong lastCheckpoint = new AtomicLong(0);
-	long checkpointIntervalMillis = 30000;
-	Logger logger = LoggerFactory.getLogger(TimeIntervalCheckpointStrategy.class);
+	private final AtomicLong lastCheckpoint = new AtomicLong(0);
+	private long checkpointIntervalMillis = 30000;
 
 	@Override
 	public Boolean call(Record record) {
@@ -35,10 +35,8 @@ public class TimeIntervalCheckpointStrategy implements CheckpointStrategy {
 		if (millisSinceLastCheckpoint > checkpointIntervalMillis) {
 			lastCheckpoint.set(System.currentTimeMillis());
 			return true;
-
 		}
 		return false;
-
 	}
 
 	public TimeIntervalCheckpointStrategy withCheckpointInterval(long time, TimeUnit unit) {

--- a/src/main/java/io/macgyver/reactor/aws/sqs/SQSReactorBridge.java
+++ b/src/main/java/io/macgyver/reactor/aws/sqs/SQSReactorBridge.java
@@ -2,9 +2,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -195,14 +195,14 @@ public class SQSReactorBridge extends AbstractReactorBridge {
         private AmazonSQSAsyncClient client;
         private AWSCredentialsProvider credentialsProvider;
         private EventBus eventBus;
-        private int waitTimeSeconds = SQSDefaults.waitTime;
+        private int waitTimeSeconds = SQSDefaults.WAIT_TIME;
         private ScheduledExecutorService executor;
         private String queueName;
         private String arn;
-        private int maxBatchSize = SQSDefaults.maxBatchSize;
-        private int visibilityTimeout = SQSDefaults.visibilityTimeout;
+        private int maxBatchSize = SQSDefaults.MAX_BATCH_SIZE;
+        private int visibilityTimeout = SQSDefaults.VISIBILITY_TIMEOUT;
         private Region region;
-        private boolean sns = SQSDefaults.snsSupport;
+        private boolean sns = SQSDefaults.SNS_SUPPORT;
 
         public Builder withRegion(Regions region) {
             return withRegion(Region.getRegion(region));
@@ -230,8 +230,8 @@ public class SQSReactorBridge extends AbstractReactorBridge {
         /**
          * The time in seconds that the client has to remove the message after the ReceiveMessageRequest before SQS
          * makes the item visible again in the queue. (default: 30 seconds)
-         * @param timeout
-         * @return
+         * @param timeout visibility timeout in seconds
+         * @return Builder
          */
         public Builder withVisibilityTimeout(int timeout) {
             this.visibilityTimeout = timeout;
@@ -286,7 +286,6 @@ public class SQSReactorBridge extends AbstractReactorBridge {
             Preconditions.checkArgument(region != null, "Region not set");
 
             c.eventBus = eventBus;
-            c.client.setRegion(region);
             if (sns) {
                 SNSAdapter.applySNSAdapter(c, c.eventBus);
             }
@@ -295,6 +294,7 @@ public class SQSReactorBridge extends AbstractReactorBridge {
             } else {
                 c.client = defaultClient();
             }
+            c.client.setRegion(region);
 
             if (!Strings.isNullOrEmpty(url)) {
                 c.urlSupplier = Suppliers.memoize(new SQSUrlSupplier(url));
@@ -437,10 +437,10 @@ public class SQSReactorBridge extends AbstractReactorBridge {
         });
     }
 
-    static class SQSDefaults {
-        static int maxBatchSize = 1;
-        static int visibilityTimeout = 30;
-        static int waitTime = 10;
-        static boolean snsSupport = false;
+    private static class SQSDefaults {
+        static final int MAX_BATCH_SIZE = 1;
+        static final int VISIBILITY_TIMEOUT = 30;
+        static final int WAIT_TIME = 10;
+        static final boolean SNS_SUPPORT = false;
     }
 }

--- a/src/main/java/io/macgyver/reactor/aws/sqs/SQSReactorBridge.java
+++ b/src/main/java/io/macgyver/reactor/aws/sqs/SQSReactorBridge.java
@@ -106,12 +106,17 @@ public class SQSReactorBridge extends AbstractReactorBridge {
     private boolean autoDeleteEnabled = true;
     private ScheduledExecutorService scheduledExecutorService;
     private int maxBatchSize = 1;
+    private int visibilityTimeout = 0;
 
     private Supplier<String> urlSupplier = new SQSUrlSupplier(null);
     private Supplier<String> arnSupplier = null;
 
     public int getMaxBatchSize() {
         return maxBatchSize;
+    }
+
+    public int getVisibilityTimeout() {
+        return visibilityTimeout;
     }
 
     public String getQueueUrl() {
@@ -195,6 +200,7 @@ public class SQSReactorBridge extends AbstractReactorBridge {
         private String queueName;
         private String arn;
         private int maxBatchSize = 1;
+        private int visibilityTimeout = 0;
         private Region region;
         private boolean sns = false;
 
@@ -218,6 +224,11 @@ public class SQSReactorBridge extends AbstractReactorBridge {
 
         public Builder withMaxBatchSize(int s) {
             this.maxBatchSize = s;
+            return this;
+        }
+
+        public Builder withVisibilityTimeout(int timeout) {
+            this.visibilityTimeout = timeout;
             return this;
         }
 
@@ -247,7 +258,6 @@ public class SQSReactorBridge extends AbstractReactorBridge {
         }
 
         public Builder withSQSClient(AmazonSQSAsyncClient client) {
-
             this.client = client;
             return this;
         }
@@ -290,6 +300,7 @@ public class SQSReactorBridge extends AbstractReactorBridge {
             c.scheduledExecutorService = executor != null ? executor : globalExecutor;
 
             c.maxBatchSize = maxBatchSize;
+            c.visibilityTimeout = visibilityTimeout;
 
             c.arnSupplier = Suppliers.memoize(new SQSArnSupplier(c.client, c.urlSupplier));
 
@@ -377,6 +388,7 @@ public class SQSReactorBridge extends AbstractReactorBridge {
                     request.setAttributeNames(ImmutableList.of("ALL"));
                     request.setWaitTimeSeconds(waitTimeSeconds);
                     request.setMaxNumberOfMessages(maxBatchSize);
+                    request.setVisibilityTimeout(visibilityTimeout);
                     Future<ReceiveMessageResult> result = client.receiveMessageAsync(request, new Handler());
                     result.get(); // go ahead and block
                 } catch (Exception e) {

--- a/src/main/java/io/macgyver/reactor/aws/sqs/SQSReactorBridge.java
+++ b/src/main/java/io/macgyver/reactor/aws/sqs/SQSReactorBridge.java
@@ -71,19 +71,14 @@ public class SQSReactorBridge extends AbstractReactorBridge {
         return arnSupplier.get();
     }
 
-    void dispatch(Message m) {
-        if (eventBus == null) {
-            logger.warn("EventBus not set...message will be discarded");
-            deleteMessageIfNecessary(m);
-        } else {
-            if (logger.isDebugEnabled()) {
-                logger.debug("dispatching on {}: {}", eventBus, m);
-            }
-            SQSMessage sm = new SQSMessage(this, m);
-            Event<SQSMessage> em = Event.wrap(sm);
-            eventBus.notify(sm, em);
-            deleteMessageIfNecessary(em);
+    private void dispatch(Message m) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("dispatching on {}: {}", eventBus, m);
         }
+        SQSMessage sm = new SQSMessage(this, m);
+        Event<SQSMessage> em = Event.wrap(sm);
+        eventBus.notify(sm, em);
+        deleteMessageIfNecessary(em);
     }
 
     protected void deleteMessageIfNecessary(Event<SQSMessage> event) {

--- a/src/main/java/io/macgyver/reactor/aws/util/MoreSelectors.java
+++ b/src/main/java/io/macgyver/reactor/aws/util/MoreSelectors.java
@@ -2,9 +2,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,8 +28,9 @@ public class MoreSelectors {
     /**
      * Generic version of Selectors.predicate()
      *
-     * @param p
-     * @return
+     * @param p typed predicate
+     * @param <T> type
+     * @return Selector
      */
     public static <T> Selector<T> typedPredicate(final Predicate<T> p) {
         Predicate<Object> x = t -> {

--- a/src/main/java/io/macgyver/reactor/aws/util/MoreSelectors.java
+++ b/src/main/java/io/macgyver/reactor/aws/util/MoreSelectors.java
@@ -2,9 +2,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,75 +14,62 @@
 package io.macgyver.reactor.aws.util;
 
 import com.fasterxml.jackson.databind.JsonNode;
-
 import reactor.bus.selector.HeaderResolver;
 import reactor.bus.selector.Selector;
 import reactor.bus.selector.Selectors;
-import reactor.fn.Consumer;
 import reactor.fn.Predicate;
 
 public class MoreSelectors {
 
-	public static Selector<JsonNode> jsonPredicate(Predicate<JsonNode> n) {
-		return typedPredicate(n);
-	}
-	
-	/**
-	 * Generic version of Selectors.predicate()
-	 * @param p
-	 * @return
-	 */
-	public static <T> Selector<T> typedPredicate(final Predicate<T> p) {
-		Predicate<Object> x = new Predicate<Object>() {
+    public static Selector<JsonNode> jsonPredicate(Predicate<JsonNode> n) {
+        return typedPredicate(n);
+    }
 
-			@Override
-			public boolean test(Object t) {
-				if (t != null) {
-					try {
-						return p.test((T) t);
-					} catch (ClassCastException e) {
-						// Not really a problem. Due to Java's type erasure,
-						// can't do an instnaceof check, so this will
-						// have to do.
-					}
-				}
-				return false;
-			}
+    /**
+     * Generic version of Selectors.predicate()
+     *
+     * @param p
+     * @return
+     */
+    public static <T> Selector<T> typedPredicate(final Predicate<T> p) {
+        Predicate<Object> x = t -> {
+            if (t != null) {
+                try {
+                    return p.test((T) t);
+                } catch (ClassCastException e) {
+                    // Not really a problem. Due to Java's type erasure,
+                    // can't do an instnaceof check, so this will
+                    // have to do.
+                }
+            }
+            return false;
+        };
+        return Selectors.predicate(x);
+    }
 
-		};
+    public static Selector all(Selector... selectors) {
+        Selector composite = new Selector() {
 
-		return Selectors.predicate(x);
-	}
+            @Override
+            public Object getObject() {
+                return this;
+            }
 
-	public static Selector all(Selector ...selectors) {
-		Selector composite = new Selector() {
+            @Override
+            public boolean matches(Object key) {
+                for (Selector s : selectors) {
+                    if (!s.matches(key)) {
+                        return false;
+                    }
+                }
+                return true;
+            }
 
-			@Override
-			public Object getObject() {
-	
-				return this;
-			}
-
-			@Override
-			public boolean matches(Object key) {
-			
-				for (Selector s: selectors) {
-					if (!s.matches(key)) {
-						return false;
-					}
-				}
-				return true;
-				
-			}
-
-			@Override
-			public HeaderResolver getHeaderResolver() {
-				// TODO Auto-generated method stub
-				return null;
-			}
-			
-		};
-		
-		return composite;
-	}
+            @Override
+            public HeaderResolver getHeaderResolver() {
+                return null;
+            }
+        };
+        return composite;
+    }
 }

--- a/src/main/java/io/macgyver/reactor/aws/util/RxJson.java
+++ b/src/main/java/io/macgyver/reactor/aws/util/RxJson.java
@@ -2,9 +2,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/io/macgyver/reactor/aws/util/RxJson.java
+++ b/src/main/java/io/macgyver/reactor/aws/util/RxJson.java
@@ -2,9 +2,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,33 +13,25 @@
  */
 package io.macgyver.reactor.aws.util;
 
-import java.io.IOException;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import rx.Observable;
 import rx.functions.Func1;
 
+import java.io.IOException;
+
 public class RxJson {
-	static Logger logger = LoggerFactory.getLogger(RxJson.class);
-	static ObjectMapper mapper = new ObjectMapper();
+    private final static Logger logger = LoggerFactory.getLogger(RxJson.class);
+    private final static ObjectMapper mapper = new ObjectMapper();
 
-	public static final Func1<String, Observable<JsonNode>> STRING_TO_JSON = new Func1<String, Observable<JsonNode>>() {
-
-			@Override
-			public Observable<JsonNode> call(String t) {
-				try {
-					return Observable.just(mapper.readTree(t));
-				} catch (IOException e) {
-					logger.info("could not parse: {}", e.toString());
-				}
-				return Observable.empty();
-			}
-		};
-	
-	
+    public static final Func1<String, Observable<JsonNode>> STRING_TO_JSON = t -> {
+        try {
+            return Observable.just(mapper.readTree(t));
+        } catch (IOException e) {
+            logger.info("could not parse: {}", e.toString());
+        }
+        return Observable.empty();
+    };
 }

--- a/src/test/java/io/macgyver/reactor/aws/sqs/SQSMessageTest.java
+++ b/src/test/java/io/macgyver/reactor/aws/sqs/SQSMessageTest.java
@@ -33,7 +33,10 @@ public class SQSMessageTest {
 		Message m = new Message();
 		
 		EventBus b = EventBus.create(Environment.initializeIfEmpty());
-		SQSReactorBridge bridge = new SQSReactorBridge.Builder().withUrl("https://api.example.com").withEventBus(b)
+		SQSReactorBridge bridge = new SQSReactorBridge.Builder()
+				.withRegion("us-west-1")
+				.withUrl("https://api.example.com")
+				.withEventBus(b)
 				.build();
 
 		SQSMessage msg = new SQSMessage(bridge,m);

--- a/src/test/java/io/macgyver/reactor/aws/sqs/SQSReactorBridgeIntegrationTest.java
+++ b/src/test/java/io/macgyver/reactor/aws/sqs/SQSReactorBridgeIntegrationTest.java
@@ -3,7 +3,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,63 +13,57 @@
  */
 package io.macgyver.reactor.aws.sqs;
 
+import com.amazonaws.services.sqs.model.Message;
+import com.google.common.collect.Lists;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import reactor.bus.Event;
+import reactor.bus.selector.Selectors;
+
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.assertj.core.api.Assertions;
-import org.junit.Test;
-
-import com.amazonaws.services.sqs.model.Message;
-import com.google.common.collect.Lists;
-
-
-import reactor.bus.Event;
-import reactor.bus.selector.Selectors;
-
 public class SQSReactorBridgeIntegrationTest extends AbstractSQSIntegrationTest {
 
-	@Test
-	public void testIt() throws InterruptedException{
+    @Test
+    public void testIt() throws InterruptedException {
+        emptyQueue();
+        SQSReactorBridge b = new SQSReactorBridge.Builder()
+                .withSQSClient(getSQSClient())
+                .withEventBus(getEventBus())
+                .withUrl(getQueueUrl())
+                .build()
+                .start();
 
-	
-		emptyQueue();
+        Assertions.assertThat(b.getQueueArn()).startsWith("arn:aws:sqs:");
+        CountDownLatch latch = new CountDownLatch(3);
+        List<Event<SQSMessage>> list = Lists.newCopyOnWriteArrayList();
 
-		SQSReactorBridge b = new SQSReactorBridge.Builder().withSQSClient(getSQSClient()).withEventBus(getEventBus())
-				.withUrl(getQueueUrl()).build().start();
+        bus.on(Selectors.T(SQSMessage.class), (Event<SQSMessage> evt) -> {
+            logger.info("Received: {}", evt);
+            list.add(evt);
+            latch.countDown();
 
-		Assertions.assertThat(b.getQueueArn()).startsWith("arn:aws:sqs:");
-		CountDownLatch latch = new CountDownLatch(3);
-		List<Event<SQSMessage>> list = Lists.newCopyOnWriteArrayList();
-		
-		bus.on(Selectors.T(SQSMessage.class), (Event<SQSMessage> evt) -> {
-			logger.info("Received: {}",evt);
-			list.add(evt);
-			latch.countDown();
-			
-		});
+        });
 
-		getSQSClient().sendMessage(getQueueUrl(), "test1");
-		getSQSClient().sendMessage(getQueueUrl(), "test2");
-		getSQSClient().sendMessage(getQueueUrl(), "test3");
-		Assertions.assertThat(latch.await(20,TimeUnit.SECONDS)).isTrue();
-		logger.info("received all: {}",list.size());
-		list.forEach(evt->{
-	
-			SQSMessage msg = evt.getData();
-			Assertions.assertThat(msg).isNotNull();
-			Assertions.assertThat(msg.getUrl()).isEqualTo(b.getQueueUrl());
-			Assertions.assertThat(msg.getBridge()).isSameAs(b);
-			Assertions.assertThat(msg.getArn()).isEqualTo(b.getQueueArn());
-			
-			Message sm = msg.getMessage();
-			
-			Assertions.assertThat(sm).isNotNull();
-			Assertions.assertThat(sm.getAttributes()).hasSize(0);
-			
-			
-			
-		});
-	
-	}
+        getSQSClient().sendMessage(getQueueUrl(), "test1");
+        getSQSClient().sendMessage(getQueueUrl(), "test2");
+        getSQSClient().sendMessage(getQueueUrl(), "test3");
+        Assertions.assertThat(latch.await(20, TimeUnit.SECONDS)).isTrue();
+        logger.info("received all: {}", list.size());
+        list.forEach(evt -> {
+
+            SQSMessage msg = evt.getData();
+            Assertions.assertThat(msg).isNotNull();
+            Assertions.assertThat(msg.getUrl()).isEqualTo(b.getQueueUrl());
+            Assertions.assertThat(msg.getBridge()).isSameAs(b);
+            Assertions.assertThat(msg.getArn()).isEqualTo(b.getQueueArn());
+
+            Message sm = msg.getMessage();
+
+            Assertions.assertThat(sm).isNotNull();
+            Assertions.assertThat(sm.getAttributes()).hasSize(0);
+        });
+    }
 }

--- a/src/test/java/io/macgyver/reactor/aws/sqs/SQSReactorBridgeTest.java
+++ b/src/test/java/io/macgyver/reactor/aws/sqs/SQSReactorBridgeTest.java
@@ -62,7 +62,10 @@ public class SQSReactorBridgeTest {
 	@Test
 	public void testBuilderSuccess() {
 
-		SQSReactorBridge bridge = new SQSReactorBridge.Builder().withEventBus(bus).withUrl("https://api.example.com")
+		SQSReactorBridge bridge = new SQSReactorBridge.Builder()
+				.withRegion("us-west-1")
+				.withEventBus(bus)
+				.withUrl("https://api.example.com")
 				.build();
 		Assertions.assertThat(bridge).isNotNull();
 		Assertions.assertThat(bridge.getFailureCount().get()).isEqualTo(0);
@@ -72,7 +75,10 @@ public class SQSReactorBridgeTest {
 		Assertions.assertThat(bridge.waitTimeSeconds).isEqualTo(10);
 
 		AmazonSQSAsyncClient sqsClient = new AmazonSQSAsyncClient(new DefaultAWSCredentialsProviderChain());
-		bridge = new SQSReactorBridge.Builder().withEventBus(bus).withUrl("https://api.example.com")
+		bridge = new SQSReactorBridge.Builder()
+				.withRegion("us-west-1")
+				.withEventBus(bus)
+				.withUrl("https://api.example.com")
 				.withSQSClient(sqsClient).build();
 
 		Assertions.assertThat(bridge.getAsyncClient()).isNotNull();


### PR DESCRIPTION
@if6was9 

* Found a small bug related to how parseJson is set for the Kinesis Builder. It was grabbing it from the bridge and not from the local value set in the Builder.
* I moved the default values in the SQS Builder into its own private class.
* Added the ability to set the visibility timeout for SQS.
* Fail fast on missing Region in SQSReactorBridge. (client.setRegion(String) will blow up if String is null)
* Tightened field visibility, fixed typos, formatting.
* Made sure messages don't get deleted in SQS because of a failure to submit the message to the eventBus

I'm happy to squash my commits.

I recommend looking at it like this to ignore whitespace changes (https://github.com/LendingClub/rx-aws/pull/5/files?w=1)